### PR TITLE
Converted supported_engines.md to actual Markdown syntax

### DIFF
--- a/docs/supported_engines.md
+++ b/docs/supported_engines.md
@@ -1,84 +1,21 @@
 
+
+
 ## Supported Engines
 
 Below is the list of supported engines with their summaries
 
-<table>
-<tr>
-<th>No</th>
-<th>Engine</th>
-<th>Returns</th>
-<tr>
-
-<tr>
-<td>1</td>
-<td>Google</td>
-<td>titles, links, descriptions</td>
-</tr>
-
-<tr>
-<td>2</td>
-<td>Yahoo</td>
-<td>titles, links, descriptions</td>
-</tr>
-
-<tr>
-<td>3</td>
-<td>Bing</td>
-<td>titles, links, descriptions</td>
-</tr>
-
-<tr>
-<td>4</td>
-<td>DuckDuckGo</td>
-<td>titles, links, descriptions</td>
-</tr>
-
-<tr>
-<td>5</td>
-<td>Baidu</td>
-<td>titles, links, descriptions</td>
-</tr>
-
-<tr>
-<td>6</td>
-<td>Yandex</td>
-<td>titles, links, descriptions</td>
-</tr>
-
-<tr>
-<td>7</td>
-<td>Aol</td>
-<td>titles, links, descriptions</td>
-</tr>
-
-<tr>
-<td>8</td>
-<td>StackOverflow</td>
-<td>titles, links, descriptions</td>
-</tr>
-
-<tr>
-<td>9</td>
-<td>GitHub</td>
-<td>titles, links, descriptions, stars, languages</td>
-</tr>
-
-<tr>
-<td>10</td>
-<td>Ask</td>
-<td> titles, links, descriptions </td>
-</tr>
-
-<tr>
-<td>11</td>
-<td>YouTube</td>
-<td>titles, links, descriptions, channels, [single videos only: durations, views, upload_dates]</td>
-</tr>
-
-<tr>
-<td>12</td>
-<td>MyAnimeList</td>
-<td>titles, links, descriptions, number of episodes, type of result (OVA, series, movie, etc.), number of episodes</td>
-</tr>
-</table>
+|No|Engine|Returns|
+|------|------|-----|
+1|Google|titles, links, descriptions
+|2|Yahoo|titles, links, descriptions
+3|Bing|titles, links, descriptions
+|4|DuckDuckGo|titles, links, descriptions
+5|Baidu|titles, links, descriptions
+|6|Yandex|titles, links, descriptions
+7|Aol|titles, links, descriptions
+8|StackOverflow|titles, links, descriptions
+9|GitHub|titles, links, descriptions, stars, languages
+10|Ask|titles, links, descriptions
+11|YouTube|titles, links, descriptions, channels, [single videos only: durations, views, upload_dates]
+12|MyAnimeList|titles, links, descriptions, number of episodes, type of result (OVA, series, movie, etc.), ratings


### PR DESCRIPTION
Hi, as per the discussion on the Group, changed the file *supported_engines.md* to have actual makdown syntax. Also fixed a small typo as MyAnimeList had **number of episodes** written twice.