### PR TITLE
Added direct results feature to Google search, Fixed typo in Bing and Stack overflow

### DIFF
--- a/search_engine_parser/core/engines/bing.py
+++ b/search_engine_parser/core/engines/bing.py
@@ -51,7 +51,7 @@ class Search(BaseSearch):
             link = link_tag.get('href')
             rdict["links"] = link
 
-        if return_type in (ReturnType.FULL, return_type.DESCRIPTIONS):
+        if return_type in (ReturnType.FULL, return_type.DESCRIPTION):
             caption = single_result.find('div', class_='b_caption')
             desc = caption.find('p')
             rdict["descriptions"] = desc.text

--- a/search_engine_parser/core/engines/google.py
+++ b/search_engine_parser/core/engines/google.py
@@ -32,6 +32,75 @@ class Search(BaseSearch):
         # find all class_='g' => each result
         return soup.find_all('div', class_='g')
 
+    def parse_result(self, results, **kwargs):
+        """
+        Runs every entry on the page through parse_single_result
+
+        :param results: Result of main search to extract individual results
+        :type results: list[`bs4.element.ResultSet`]
+        :returns: dictionary. Containing lists of titles, links, descriptions, direct results and other possible\
+            returns.
+        :rtype: dict
+        """
+        search_results = dict()
+        for each in results:
+            try:
+                rdict = self.parse_single_result(each, **kwargs)
+                # Create a list for all keys in rdict if not exist, else
+                for key in rdict.keys():
+                    if key not in search_results.keys():
+                        search_results[key] = list([rdict[key]])
+                    else:
+                        search_results[key].append(rdict[key])
+            except Exception: #pylint: disable=invalid-name, broad-except
+                pass
+
+        direct_answer = self.parse_direct_answer(results[0])
+        if direct_answer is not None:
+            search_results['direct_answer'] = direct_answer
+
+        return search_results
+
+    def parse_direct_answer(self, single_result, return_type=ReturnType.FULL):
+        # returns empty string when there is no direct answer
+        if return_type in (ReturnType.FULL, ReturnType.DESCRIPTION):
+            direct_answer = ''
+            if not single_result.find('span', class_='st'):
+                # example query: President of US
+                if single_result.find('div', class_='Z0LcW'):
+                    direct_answer = single_result.find('div', class_='Z0LcW').find('a').text
+                
+                # example query: 5+5
+                elif single_result.find('span', class_='qv3Wpe'):
+                    direct_answer = single_result.find('span', class_='qv3Wpe').text            
+                
+                # example query: Weather in dallas
+                elif single_result.find('div', id='wob_wc'):
+                    weather_status = single_result.find('span', id='wob_dc').text
+                    temperature = single_result.find('span', id='wob_tm').text
+                    unit = single_result.find('div', class_='wob-unit').find('span', class_='wob_t').text
+                    direct_answer = weather_status + ', ' + temperature + unit  
+                
+                # example query: 100 euros in pounds
+                elif single_result.find('span', class_='DFlfde SwHCTb'):
+                    direct_answer = single_result.find('span', class_='DFlfde SwHCTb').text + ' ' +single_result.find('span', class_='MWvIVe').text
+
+                # example query: US time
+                elif single_result.find('div', class_="gsrt vk_bk dDoNo"):
+                    direct_answer = single_result.find('div', class_='gsrt vk_bk dDoNo').text
+
+                # Christmas
+                elif single_result.find('div', class_="zCubwf"):
+                    direct_answer = single_result.find('div', class_="zCubwf").text
+
+            
+            elif not single_result.find('span', class_='st').text:
+                # example queris: How long shoud a car service take?, fastest animal
+                if single_result.find('div', class_='Z0LcW'):
+                    direct_answer = single_result.find('div', class_='Z0LcW').text
+        
+        return direct_answer
+
     def parse_single_result(self, single_result, return_type=ReturnType.FULL):
         """
         Parses the source code to return

--- a/search_engine_parser/core/engines/stackoverflow.py
+++ b/search_engine_parser/core/engines/stackoverflow.py
@@ -53,7 +53,7 @@ class Search(BaseSearch):
             link = self.base_url + ref_link
             rdict["links"] = link
 
-        if return_type in (ReturnType.FULL, return_type.DESCRIPTIONS):
+        if return_type in (ReturnType.FULL, return_type.DESCRIPTION):
             caption = single_result.find('div', class_='excerpt')
             rdict["descriptions"] = caption.text
         return rdict


### PR DESCRIPTION
name: Direct Answer Implementation
about: Implemented a new feature in Google Search
title: 'Direct answer'
labels: 'feature', 'needs-review'
assignees: '@deven96', '@MeNsaaH'

Example:
"President of US" returns {..., 'direct_answer': 'Donald Trump', ...}
"5+5" returns {..., 'direct_answer': '10', ...}
"Weather in dallas" returns {..., 'direct_answer': 'Sunny, 17°C', ...}
"100 euros in pounds" returns {..., 'direct_answer': '87.34 Pound sterling', ...}
"US time" returns {..., 'direct_answer': '8:23 am', ...}
"Christmas" returns {..., 'direct_answer': 'Friday, 25 December', ...}
"How long should a car service take?" returns {..., 'direct_answer': '3 hours', ...}
"A query without direct answer" returns {..., 'direct_answer': '', ...}