### PR TITLE
Fix to runtime error when running on a(my) api

### DIFF
--- a/search_engine_parser/core/base.py
+++ b/search_engine_parser/core/base.py
@@ -180,6 +180,7 @@ class BaseSearch:
         :return: dictionary. Containing titles, links, netlocs and descriptions.
         """
         # Get search Page Results
+	asyncio.set_event_loop(asyncio.new_event_loop())
         loop = asyncio.get_event_loop()
         soup = loop.run_until_complete(
             self.get_soup(


### PR DESCRIPTION
When trying to use this together with a Flask Restful API you run into a runtime error "there is no current event loop in thread.
I fixed that by creating a new "loop" before assigning the loop variable.
I haven't tested it out when not using my api, yet... But I really think that it shouldn't make any difference