### PR TITLE
feat: default safe search enabled for Google search

### DIFF
--- a/search_engine_parser/core/engines/google.py
+++ b/search_engine_parser/core/engines/google.py
@@ -12,7 +12,7 @@ import urllib.parse as urlparse
 from search_engine_parser.core.base import BaseSearch, ReturnType, SearchItem
 
 
-EXTRA_PARAMS = ('hl', 'tbs')
+EXTRA_PARAMS = ('hl', 'tbs', 'safe')
 
 
 class Search(BaseSearch):
@@ -36,6 +36,7 @@ class Search(BaseSearch):
         params["start"] = (page-1) * 10
         params["q"] = query
         params["gbv"] = 1
+        params["safe"] = "active"
         # additional parameters will be considered
         for param in EXTRA_PARAMS:
             if kwargs.get(param):


### PR DESCRIPTION
by default set `safe = "active"`
inorder to turnoff, one can add the parameter in kwargs as `safe = "off"`


usage:

```python

search_args = ('hello world', 1)
gsearch = GoogleSearch()
gresults = gsearch.search(*search_args, safe='off') 
```

This PR will close #126 